### PR TITLE
Use _unrecorded_attributes

### DIFF
--- a/custom_components/file_plusplus/sensor.py
+++ b/custom_components/file_plusplus/sensor.py
@@ -77,7 +77,7 @@ async def async_setup_entry(
 class FileSensor(SensorEntity):
     """Implementation of a file sensor."""
 
-    _entity_component_unrecorded_attributes = frozenset(
+    _unrecorded_attributes = frozenset(
         {"content"}
     )
 


### PR DESCRIPTION
Use _unrecorded_attributes instead of _entity_component_unrecorded_attributes https://developers.home-assistant.io/docs/core/entity/#excluding-state-attributes-from-recorder-history